### PR TITLE
Add sideEffects: false to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/esm5/index.js",
+  "sideEffects": false,
   "name": "rxjs-etc",
   "optionalDependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
This allows tree-shaking to work properly with this library: https://github.com/webpack/webpack/tree/master/examples/side-effects

I haven't verified that it's safe in this library, but I'm assuming so.