### PR TITLE
Fix docs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ source.pipe(endWith("this is the end"))
 
 A bunch of utility functions that do what their names suggest:
 
-* [isNulled/isNotNulled](./source/util.ts)
+* [isNulled/isNonNulled](./source/util.ts)
 
     `isNulled` returns `true` if a value is `null` or `undefined`.
 


### PR DESCRIPTION
Fix typo to match export.

https://github.com/cartant/rxjs-etc/blob/3a5ddc0325d9dc5baaab55d84a17e933638db0e9/source/util.ts#L15