### PR TITLE
fix: update package.json files for submodule imports

### DIFF
--- a/observable/package.json
+++ b/observable/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "../dist/cjs/observable/index.js",
+  "module": "../dist/esm/observable/index.js",
+  "name": "rxjs-etc/observable",
+  "sideEffects": false,
+  "typings": "../dist/esm/observable/index.d.ts"
+}

--- a/operators/package.json
+++ b/operators/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "../dist/cjs/operators/index.js",
+  "module": "../dist/esm/operators/index.js",
+  "name": "rxjs-etc/operators",
+  "sideEffects": false,
+  "typings": "../dist/esm/operators/index.d.ts"
+}

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -1,0 +1,7 @@
+{
+  "main": "../dist/cjs/scheduler/index.js",
+  "module": "../dist/esm/scheduler/index.js",
+  "name": "rxjs-etc/scheduler",
+  "sideEffects": false,
+  "typings": "../dist/esm/scheduler/index.d.ts"
+}

--- a/source/observable/package.json
+++ b/source/observable/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "rxjs-etc/observable",
-  "typings": "./index.d.ts",
-  "main": "./index.js",
-  "module": "../esm5/observable/index.js",
-  "es2015": "../esm2015/observable/index.js",
-  "sideEffects": false
-}

--- a/source/operators/package.json
+++ b/source/operators/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "rxjs-etc/operators",
-  "typings": "./index.d.ts",
-  "main": "./index.js",
-  "module": "../esm5/operators/index.js",
-  "es2015": "../esm2015/operators/index.js",
-  "sideEffects": false
-}

--- a/source/scheduler/package.json
+++ b/source/scheduler/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "rxjs-etc/scheduler",
-  "typings": "./index.d.ts",
-  "main": "./index.js",
-  "module": "../esm5/scheduler/index.js",
-  "es2015": "../esm2015/scheduler/index.js",
-  "sideEffects": false
-}


### PR DESCRIPTION
This pull request aims to fix the package.json files which enable submodule imports like this:

```ts
import { pairwiseStartWith } from 'rxjs-etc/operators';
```

Please let me know if anything needs to change.