### PR TITLE
Fix: Export equals.

### DIFF
--- a/source/operators/index.ts
+++ b/source/operators/index.ts
@@ -16,6 +16,7 @@ export * from "./deferFinalize";
 export * from "./delayUntil";
 export * from "./dispose";
 export * from "./endWith";
+export * from "./equals";
 export * from "./exhaustTap";
 export * from "./finalizeWithKind";
 export * from "./guard";


### PR DESCRIPTION
This pull request adds the missing export for the equals operator.