### PR TITLE
Add zipObject() operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ npm install rxjs-etc --save
 
     Higher-order variants of `combineLatestArray` - that takes `Observable<Observable<T>[]>` and returns `Observable<T[]>` - and `combineLatestObject`.
 
-* [combineLatestObject](./source/observable/combineLatestObject.ts), [forkJoinObject](./source/observable/forkJoinObject.ts)
+* [combineLatestObject](./source/observable/combineLatestObject.ts), [forkJoinObject](./source/observable/forkJoinObject.ts), [zipObject](./source/observable/zipObject.ts)
 
-    Like the array versions, but these take objects. Observable properties are combined using either `combineLatest` or `forkJoin`.
+    Like the array versions, but these take objects. Observable properties are combined using either `combineLatest`, `forkJoin` or `zip`.
 
 * [forkJoinConcurrent](./source/observable/forkJoinConcurrent.ts)
 

--- a/source/observable/index.ts
+++ b/source/observable/index.ts
@@ -25,3 +25,4 @@ export * from "./toggle";
 export * from "./traverse";
 export * from "./zipArray";
 export * from "./zipPadded";
+export * from "./zipObject";

--- a/source/observable/zipObject-spec.ts
+++ b/source/observable/zipObject-spec.ts
@@ -1,0 +1,73 @@
+/**
+ * @license Use of this source code is governed by an MIT-style license that
+ * can be found in the LICENSE file at https://github.com/cartant/rxjs-etc
+ */
+/*tslint:disable:no-unused-expression*/
+
+import { marbles } from "rxjs-marbles";
+import { zipObject } from "./zipObject";
+
+describe("zipObject", () => {
+  it(
+    "should zip the Observable values of an object and mirror that object with the notification values",
+    marbles((m) => {
+      const a = m.hot("         --a");
+      const b = m.hot("         ---b");
+      const expected = m.cold(" ---i", { i: { a: "a", b: "b" } });
+      const destination = zipObject({ a, b });
+      m.expect(destination).toBeObservable(expected);
+    })
+  );
+
+  it(
+    "should support multiple notifications from the input observables",
+    marbles((m) => {
+      const a = m.hot("         --a-c");
+      const b = m.hot("         ---b-d");
+      const expected = m.cold(" ---i-j", {
+        i: { a: "a", b: "b" },
+        j: { a: "c", b: "d" },
+      });
+      const destination = zipObject({ a, b });
+      m.expect(destination).toBeObservable(expected);
+    })
+  );
+
+  it(
+    "should support empty objects",
+    marbles((m) => {
+      const expected = m.cold("(i|)", { i: {} });
+      const destination = zipObject({});
+      m.expect(destination).toBeObservable(expected);
+    })
+  );
+
+  it(
+    "should support objects with single property",
+    marbles((m) => {
+      const a = m.hot("         --a");
+      const expected = m.cold(" --i", { i: { a: "a" } });
+      const destination = zipObject({ a });
+      m.expect(destination).toBeObservable(expected);
+    })
+  );
+
+  it(
+    "should support objects with non-observable properties",
+    marbles((m) => {
+      const expected = m.cold("(i|)", { i: { a: "a" } });
+      const destination = zipObject({ a: "a" });
+      m.expect(destination).toBeObservable(expected);
+    })
+  );
+
+  it(
+    "should support objects with some non-observable properties",
+    marbles((m) => {
+      const a = m.hot("         --a");
+      const expected = m.cold(" --(i|)", { i: { a: "a", b: "b" } });
+      const destination = zipObject({ a, b: "b" });
+      m.expect(destination).toBeObservable(expected);
+    })
+  );
+});

--- a/source/observable/zipObject.ts
+++ b/source/observable/zipObject.ts
@@ -1,0 +1,61 @@
+/**
+ * @license Use of this source code is governed by an MIT-style license that
+ * can be found in the LICENSE file at https://github.com/cartant/rxjs-etc
+ */
+
+import { Observable, of } from "rxjs";
+import { map } from "rxjs/operators";
+import { isObservable } from "../util";
+import { zipArray } from "./zipArray";
+
+/**
+ * Like the `zip` operator, but instead of an array, it takes an object. The properties of this object can be Observable
+ * or non-Observable. `zipObject` subscribes to the Observable properties and combines them into an object that mirrors
+ * the input object, but with the notification values of those Observables. Non-Observable values are wrapped with `of` before zipping.
+ *
+ * ## Example
+ * Combine name, weight, and species of animals
+ * ```typescript
+ * import { zipObject } from 'rxjs-etc';
+ *
+ * let name$ = of('kitty', 'doggo', 'chirpy');
+ * let weight$ = of(4, 7, 0.5);
+ * let species$ = of('Dog', 'Cat', 'Bird');
+ *
+ * zipObject({
+ *   name: name$,
+ *   weight: weight$,
+ *   species: species$
+ * })
+ * .subscribe(value => console.log(value));
+ *
+ * // Output:
+ * // { name: 'kitty', weight: 4, species: 'Cat'}
+ * // { name: 'doggo', weight: 7, species: 'Dog' }
+ * // { name: 'chirpy', weight: 0.5, species: 'Bird' }
+ * ```
+ * @param instance
+ * @return {Observable<T>}
+ * @static true
+ * @name zipObject
+ */
+export function zipObject<T>(
+  instance: { [K in keyof T]: T[K] | Observable<T[K]> }
+): Observable<T> {
+  type K = keyof T;
+  const entries = Object.entries(instance) as [
+    string,
+    T[K] | Observable<T[K]>
+  ][];
+  const observables = entries.map(([, value]) =>
+    isObservable(value) ? value : of(value)
+  );
+  return zipArray(observables).pipe(
+    map((values) =>
+      values.reduce(
+        (acc, value, index) => ({ ...acc, [entries[index][0]]: value }),
+        {} as T
+      )
+    )
+  );
+}


### PR DESCRIPTION
I've found this thread on SO (https://stackoverflow.com/questions/62117079/simple-way-to-combine-many-observables-into-one-object) and thought this operator could help folks like them. Would've been useful to me as well from time to time. Usage:

```ts
zipObject({
  name: name$,
  weight: weight$,
  species: species$
})
```
