### PR TITLE
feat: Add filterNullable

### DIFF
--- a/source/operators/filterNullable-spec.ts
+++ b/source/operators/filterNullable-spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @license Use of this source code is governed by an MIT-style license that
+ * can be found in the LICENSE file at https://github.com/cartant/rxjs-etc
+ */
+
+import { marbles } from "rxjs-marbles";
+import { filterNullable } from "./filterNullable";
+
+// prettier-ignore
+describe("filterNullable", () => {
+  it(
+    "should not filter falsy values except for null and undefined",
+    marbles(m => {
+      const values = { a: 0, b: false, c: NaN, d: "" };
+
+      const source = m.cold("   -a-b-c-d-|", values);
+      const subs = "            ^--------!";
+      const expected = m.cold(" -a-b-c-d-|", values);
+
+      const destination = source.pipe(
+        filterNullable()
+      );
+      m.expect(destination).toBeObservable(expected);
+      m.expect(source).toHaveSubscriptions(subs);
+    })
+  );
+
+  it(
+    "should filter null and undefined",
+    marbles(m => {
+      const values = { a: null, b: 1, c: undefined };
+
+      const source = m.cold("   -a-b-c-|", values);
+      const subs = "            ^------!";
+      const expected = m.cold(" ---b---|", { b: values.b });
+
+      const destination = source.pipe(
+        filterNullable()
+      );
+      m.expect(destination).toBeObservable(expected);
+      m.expect(source).toHaveSubscriptions(subs);
+    })
+  );
+});

--- a/source/operators/filterNullable.ts
+++ b/source/operators/filterNullable.ts
@@ -1,0 +1,14 @@
+/**
+ * @license Use of this source code is governed by an MIT-style license that
+ * can be found in the LICENSE file at https://github.com/cartant/rxjs-etc
+ */
+
+import { Observable, OperatorFunction } from "rxjs";
+import { filter } from "rxjs/operators";
+
+export function filterNullable<T>(): OperatorFunction<T, NonNullable<T>> {
+  return (source: Observable<T>) =>
+    source.pipe(
+      filter((x): x is NonNullable<T> => x !== null && x !== undefined)
+    );
+}

--- a/source/operators/index.ts
+++ b/source/operators/index.ts
@@ -19,6 +19,7 @@ export * from "./dispose";
 export * from "./endWith";
 export * from "./equals";
 export * from "./exhaustTap";
+export * from "./filterNullable";
 export * from "./finalizeWithKind";
 export * from "./guard";
 export * from "./hold";


### PR DESCRIPTION
This pull request adds the `filterNullable()` operator. It is functionally equivalent to `filter((x) => x !== null && x !== undefined)`. It converts `Observable<T>` to `Observable<NonNullable<T>>`